### PR TITLE
Smtlib_lexer: recognize strings

### DIFF
--- a/lib/Smtlib_lexer.mll
+++ b/lib/Smtlib_lexer.mll
@@ -7,7 +7,8 @@ let simple_symbol_char = [ 'A'-'Z' 'a'-'z' '+' '-' '/' '*' '=' '%' '?' '!' '.' '
 let simple_symbol = simple_symbol_char (['0' - '9'] | simple_symbol_char )*
 let keyword = ':' simple_symbol
 let blank = [ ' ' '\t' ]
-let numeral = ((['-']?['1'-'9']['0'-'9']*) | ['0'])
+let numeral = (( ['-']?['1'-'9']['0'-'9']* ) | ['0'])
+let string = ("\\\"" | [^ '"'])*
 
 rule token = parse
   | ";" [^ '\n' '\r']+ { token lexbuf }
@@ -18,6 +19,7 @@ rule token = parse
   | numeral as n { INT (int_of_string n) }
   | "(" { LPAREN }
   | ")" { RPAREN }
+  | "\"" (string as x) "\"" { STRING x }
   | simple_symbol as x { SYMBOL x }
   | keyword as x { KEYWORD x }
 


### PR DESCRIPTION
Strings are inside double-quotes, and contain either the 2-char
sequence \" or a bunch of non-double-quote characters.
