### PR TITLE
Smtlib: don't hang on read() forever if we launch a non-existant proc

### DIFF
--- a/lib/Smtlib.ml
+++ b/lib/Smtlib.ml
@@ -1,6 +1,6 @@
 include Smtlib_syntax
 
-type solver = { stdin : out_channel; stdout_lexbuf : Lexing.lexbuf }
+type solver = { stdin : out_channel; stdout : in_channel; stdout_lexbuf : Lexing.lexbuf }
 
 (* Does not flush *)
 let rec write_sexp (out_chan : out_channel) (e : sexp): unit = match e with
@@ -38,6 +38,22 @@ let command (solver : solver) (sexp : sexp) = write solver sexp; read solver
 let print_success_command =
   SList [SSymbol "set-option"; SKeyword ":print-success"; SSymbol "true"]
 
+(* keep track of all solvers we spawn, so we can close our read/write
+   FDs when the solvers exit *)
+let _solvers : (int * solver) list ref = ref []
+
+let handle_sigchild (_ : int) : unit =
+  let open Printf in
+  let (pid, status) = Unix.waitpid [] (-1) in
+  eprintf "solver child (pid %d) exited\n%!" pid;
+  try
+    let solver = List.assoc pid !_solvers in
+    close_in_noerr solver.stdout; close_out_noerr solver.stdin
+  with
+    _ -> ()
+
+let () = Sys.set_signal Sys.sigchld (Sys.Signal_handle handle_sigchild)
+
 let make_solver (z3_path : string) : solver =
   let open Unix in
   let (z3_stdin, z3_stdin_writer) = pipe () in
@@ -52,7 +68,8 @@ let make_solver (z3_path : string) : solver =
   let out_chan = out_channel_of_descr z3_stdin_writer in
   set_binary_mode_out out_chan false;
   set_binary_mode_in in_chan false;
-  let solver = { stdin = out_chan; stdout_lexbuf = Lexing.from_channel in_chan } in
+  let solver = { stdin = out_chan; stdout = in_chan; stdout_lexbuf = Lexing.from_channel in_chan } in
+  _solvers := (pid, solver) :: !_solvers;
   match command solver print_success_command with
     | SSymbol "success" -> solver
     | _ -> failwith "could not configure solver to :print-success"

--- a/lib/Smtlib.ml
+++ b/lib/Smtlib.ml
@@ -70,9 +70,12 @@ let make_solver (z3_path : string) : solver =
   set_binary_mode_in in_chan false;
   let solver = { stdin = out_chan; stdout = in_chan; stdout_lexbuf = Lexing.from_channel in_chan } in
   _solvers := (pid, solver) :: !_solvers;
-  match command solver print_success_command with
-    | SSymbol "success" -> solver
-    | _ -> failwith "could not configure solver to :print-success"
+  try
+    match command solver print_success_command with
+      | SSymbol "success" -> solver
+      | _ -> failwith "could not configure solver to :print-success"
+  with
+    Sys_error("Bad file descriptor") -> failwith "couldn't talk to solver, double-check path"
 
 let sexp_to_string (sexp : sexp) : string =
   let open Buffer in


### PR DESCRIPTION
With this change, if I set my `z3_path` to `"z3333333"`, I get:

```
$ ./Main.d.byte tests/file.c
solver child (pid 20939) exited
Fatal error: exception Failure("couldn't talk to solver, double-check path")
```

If `z3` is killed or dies at some point later on in execution (due to out-of-memory or whatever), we would see:

```
solver child (pid 19717) exited
Fatal error: exception Sys_error("Bad file descriptor")
```

The next time `command`  is used.  Basically - it causes an exception to be thrown in `command`, either when writing to or reading from the file descriptor.  This was the only non-racy way I could think to do this, but it is certainly ugly and the error is completely non-obvious.

This would prevent the hang here: https://piazza.com/class/ick7kspf4we2tr?cid=74 , replacing it with a somewhat inscrutable error :\  I think a better error would involve changing `command` to return a `Result`.
